### PR TITLE
update examples to use deepspeech-hotword-node>=0.1.1

### DIFF
--- a/examples/hotword/package.json
+++ b/examples/hotword/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "bumblebee-deepspeech": "file:../../",
-    "bumblebee-hotword-node": "0.0.10",
+    "bumblebee-hotword-node": ">=0.1.1",
     "play-sound-file": "0.0.2"
   }
 }

--- a/examples/microphone/package.json
+++ b/examples/microphone/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bumblebee-hotword-node": "0.0.10",
+    "bumblebee-hotword-node": ">=0.1.1",
     "bumblebee-deepspeech": "file:../../"
   }
 }


### PR DESCRIPTION
This fixes the issue https://github.com/jaxcore/bumblebee-hotword-node/issues/6 from affecting bumblebee-deepspeech, and ensures compatibility with future updates.